### PR TITLE
Fix OBO error in get_color

### DIFF
--- a/tracks/track.c
+++ b/tracks/track.c
@@ -523,7 +523,7 @@ static void get_color(double *r, double *g, double *b, struct pos *pos)
     return;
   }
 
-  for (i = 0; winds[i + 1] < pos->wind && i < 6; i++) {
+  for (i = 0; i < 6 && winds[i + 1] < pos->wind; i++) {
     /* Skip down until we get to the right category. */
   }
   *r = colors[i][0];


### PR DESCRIPTION
Due to short-circuit evaluation, this is technically a buffer overflow. For Category 5 points, i will be 6, meaning winds[i + 1] = winds[7] is out-of-bounds. Thus depending on platform, this behavior is undefined, since winds[7] is whatever happens to be on the stack right afterwards, and in particular, the condition winds[i + 1] < pos->wind could be evaluated to true an indefinite number of times, making the loop ignore the bounds check i < 6 until this stops returning true. This bug is platform-dependent as what's on the stack right after the winds array is entirely at the discretion of the compiler and platform.