### PR TITLE
Add support for optional color arguments and future support for multiple scales

### DIFF
--- a/tracks/Makefile.am
+++ b/tracks/Makefile.am
@@ -1,5 +1,5 @@
 bin_PROGRAMS = track
 
-track_SOURCES = template.c template.h tab.c tab.h tcr.c tcr.h atcf.c atcf.h hurdat2.c hurdat2.h hurdat.c hurdat.h md.c md.h track.c track.h
+track_SOURCES = scales.c template.c template.h tab.c tab.h tcr.c tcr.h atcf.c atcf.h hurdat2.c hurdat2.h hurdat.c hurdat.h md.c md.h scales.h track.c track.h
 AM_CFLAGS = $(TRACK_CFLAGS)
 track_LDADD = $(TRACK_LIBS)

--- a/tracks/scales.c
+++ b/tracks/scales.c
@@ -3,17 +3,83 @@
 			  ((double)(g) / (double)0xFF),	\
 			  ((double)(b) / (double)0xFF)}
 # define IND_COLOR(c) (double)(c) / (double)0xFF
+
+/* SSHWS (1-minute winds). Default option. */
 struct colormapentry SSHWS_ENTRIES[8] = {
-		{.name = "TD", .value = COLOR(0x5e, 0xba, 0xff), .wind = 0},
-		{.name = "TS", .value = COLOR(0x00, 0xfa, 0xf4), .wind = 34},
-		{.name = "C1", .value = COLOR(0xff, 0xff, 0xcc), .wind = 64},
-		{.name = "C2", .value = COLOR(0xff, 0xe7, 0x75), .wind = 83},
-		{.name = "C3", .value = COLOR(0xff, 0xc1, 0x40), .wind = 96},
-		{.name = "C4", .value = COLOR(0xff, 0x8f, 0x20), .wind = 114},
-		{.name = "C5", .value = COLOR(0xff, 0x60, 0x60), .wind = 136},
-		{.name = "SENTINEL", .value = COLOR(0xff, 0xff, 0xff), .wind = 0x7fffffff}
-	};
+	{.name = "TD", .value = COLOR(0x5e, 0xba, 0xff), .wind = 0},
+	{.name = "TS", .value = COLOR(0x00, 0xfa, 0xf4), .wind = 34},
+	{.name = "C1", .value = COLOR(0xff, 0xff, 0xcc), .wind = 64},
+	{.name = "C2", .value = COLOR(0xff, 0xe7, 0x75), .wind = 83},
+	{.name = "C3", .value = COLOR(0xff, 0xc1, 0x40), .wind = 96},
+	{.name = "C4", .value = COLOR(0xff, 0x8f, 0x20), .wind = 114},
+	{.name = "C5", .value = COLOR(0xff, 0x60, 0x60), .wind = 136},
+	{.name = "SENTINEL", .value = COLOR(0xff, 0xff, 0xff), .wind = 0x7fffffff}
+};
 struct colormap SSHWS_COLORMAP = {
 	.numcolors = 7,
-	.entries = SSHWS_ENTRIES
+	.entries = SSHWS_ENTRIES,
+	.disturbancecolor = COLOR(0x80, 0xcc, 0xff)
+};
+
+/* AUS scale (10-minute winds). */
+struct colormapentry AUS_ENTRIES[7] = {
+	{.name = "TL", .value = COLOR(0x53, 0xba, 0xff), .wind = 0},
+	{.name = "C1", .value = COLOR(0x00, 0xfa, 0xf4), .wind = 34},
+	{.name = "C2", .value = COLOR(0xcc, 0xff, 0xff), .wind = 48},
+	{.name = "C3", .value = COLOR(0xff, 0xcc, 0xcc), .wind = 64},
+	{.name = "C4", .value = COLOR(0xff, 0xc1, 0x40), .wind = 86},
+	{.name = "C5", .value = COLOR(0xff, 0x60, 0x60), .wind = 107},
+	{.name = "SENTINEL", .value = COLOR(0xff, 0xff, 0xff), .wind = 0x7fffffff}
+};
+struct colormap AUS_COLORMAP = {
+	.numcolors = 6,
+	.entries = AUS_ENTRIES,
+	.disturbancecolor = COLOR(0x80, 0xcc, 0xff)
+};
+
+/* IMD scale (3-minute winds). */
+struct colormapentry IMD_ENTRIES[8] = {
+	{.name = "D", .value = COLOR(0x80, 0xcc, 0xff), .wind = 0},
+	{.name = "DD", .value = COLOR(0x5e, 0xba, 0xff), .wind = 28},
+	{.name = "CS", .value = COLOR(0x00, 0xfa, 0xf4), .wind = 34},
+	{.name = "SCS", .value = COLOR(0xcc, 0xff, 0xff), .wind = 48}, 
+	{.name = "VSCS", .value = COLOR(0xff, 0xcc, 0xcc), .wind = 65},
+	{.name = "ESCS", .value = COLOR(0xff, 0xc1, 0x40), .wind = 90},
+	{.name = "SUCS", .value = COLOR(0xff, 0x60, 0x60), .wind = 120},
+	{.name = "SENTINEL", .value = COLOR(0xff, 0xff, 0xff), .wind = 0x7fffffff}
+};
+struct colormap IMD_COLORMAP = {
+	.numcolors = 7,
+	.entries = IMD_ENTRIES,
+	.disturbancecolor = COLOR(0x80, 0xcc, 0xff) // disturbancecolor here must be understood as "well-marked low pressure area"; this is not a permanent color choice.
+};
+
+/* JMA scale (10-minute winds). */
+struct colormapentry JMA_ENTRIES[5] = {
+	{.name = "TD", .value = COLOR(0x5e, 0xba, 0xff), .wind = 0},
+	{.name = "TS", .value = COLOR(0x00, 0xfa, 0xf4), .wind = 34},
+	{.name = "STS", .value = COLOR(0xcc, 0xff, 0xff), .wind = 48}, 
+	{.name = "TY", .value = COLOR(0xfd, 0xaf, 0x9a), .wind = 64},
+	{.name = "SENTINEL", .value = COLOR(0xff, 0xff, 0xff), .wind = 0x7fffffff}	
+};
+struct colormap JMA_COLORMAP = {
+	.numcolors = 4,
+	.entries = JMA_ENTRIES,
+	.disturbancecolor = COLOR(0x80, 0xcc, 0xff) // NOT USED in this basin.
+};
+
+/* MFR scale (10-minute winds). */
+struct colormapentry MFR_ENTRIES[7] = {
+	{.name = "TD", .value = COLOR(0x53, 0xba, 0xff), .wind = 0},
+	{.name = "MTS", .value = COLOR(0x00, 0xfa, 0xf4), .wind = 34},
+	{.name = "STS", .value = COLOR(0xcc, 0xff, 0xff), .wind = 48},
+	{.name = "TC", .value = COLOR(0xff, 0xcc, 0xcc), .wind = 64},
+	{.name = "ITC", .value = COLOR(0xff, 0xc1, 0x40), .wind = 86},
+	{.name = "VITC", .value = COLOR(0xff, 0x60, 0x60), .wind = 116},
+	{.name = "SENTINEL", .value = COLOR(0xff, 0xff, 0xff), .wind = 0x7fffffff}
+};
+struct colormap MFR_COLORMAP = {
+	.numcolors = 6,
+	.entries = MFR_ENTRIES,
+	.disturbancecolor = COLOR(0x80, 0xcc, 0xff)
 };

--- a/tracks/scales.c
+++ b/tracks/scales.c
@@ -1,0 +1,19 @@
+# include "scales.h"
+#  define COLOR(r, g, b) {((double)(r) / (double)0xFF),	\
+			  ((double)(g) / (double)0xFF),	\
+			  ((double)(b) / (double)0xFF)}
+# define IND_COLOR(c) (double)(c) / (double)0xFF
+struct colormapentry SSHWS_ENTRIES[8] = {
+		{.name = "TD", .value = COLOR(0x5e, 0xba, 0xff), .wind = 0},
+		{.name = "TS", .value = COLOR(0x00, 0xfa, 0xf4), .wind = 34},
+		{.name = "C1", .value = COLOR(0xff, 0xff, 0xcc), .wind = 64},
+		{.name = "C2", .value = COLOR(0xff, 0xe7, 0x75), .wind = 83},
+		{.name = "C3", .value = COLOR(0xff, 0xc1, 0x40), .wind = 96},
+		{.name = "C4", .value = COLOR(0xff, 0x8f, 0x20), .wind = 114},
+		{.name = "C5", .value = COLOR(0xff, 0x60, 0x60), .wind = 136},
+		{.name = "SENTINEL", .value = COLOR(0xff, 0xff, 0xff), .wind = 0x7fffffff}
+	};
+struct colormap SSHWS_COLORMAP = {
+	.numcolors = 7,
+	.entries = SSHWS_ENTRIES
+};

--- a/tracks/scales.h
+++ b/tracks/scales.h
@@ -1,0 +1,19 @@
+#ifndef __SCALE_H__
+#define __SCALE_H__
+#endif
+
+#define SSHWS_CODE 0
+#define AUS_CODE 1
+#define IMD_CODE 2
+#define JMA_CODE 3
+#define MFR_CODE 4
+struct colormapentry {
+	double value[3];
+	int wind;
+	char* name;
+};
+struct colormap {
+	int numcolors;
+	struct colormapentry *entries;
+};
+struct colormap SSHWS_COLORMAP;

--- a/tracks/scales.h
+++ b/tracks/scales.h
@@ -15,5 +15,16 @@ struct colormapentry {
 struct colormap {
 	int numcolors;
 	struct colormapentry *entries;
+	double disturbancecolor[3]; // For PTC/DI/TDI. Can be overridden using the distcolor argument.
+	// The disturbance color is considered separately from the other entries since unlike the others, it is not uniquely determined by storm intensity, overlapping with depressions.
 };
+struct colormapentry SSHWS_ENTRIES[8];
 struct colormap SSHWS_COLORMAP;
+struct colormapentry AUS_ENTRIES[7];
+struct colormap AUS_COLORMAP;
+struct colormapentry IMD_ENTRIES[8];
+struct colormap IMD_COLORMAP;
+struct colormapentry JMA_ENTRIES[5];
+struct colormap JMA_COLORMAP;
+struct colormapentry MFR_ENTRIES[7];
+struct colormap MFR_COLORMAP;

--- a/tracks/track.c
+++ b/tracks/track.c
@@ -111,7 +111,20 @@ static void init_storm_arg(struct storm_arg *stormp)
 
   *stormp = storm;
 }
-
+static int get_scale_code(const char* scalename) {
+	if (strcasecmp("AUS", scalename) == 0) {
+		return AUS_CODE;
+	} else if (strcasecmp("IMD", scalename) == 0) {
+		return IMD_CODE;
+	} else if (strcasecmp("JMA", scalename) == 0) {
+		return JMA_CODE;
+	} else if (strcasecmp("MFR", scalename) == 0) {
+		return MFR_CODE;
+	}
+	else {
+		return SSHWS_CODE;
+	}
+}
 static void init_color_arg(struct colormap *colorp, int scale) {
 	struct colormap colors;
    switch (scale) {
@@ -208,6 +221,11 @@ static struct args read_args(int argc, char **argv)
       if (strcasecmp(argv[i], "--input") == 0) {
 	i++;
 	args.storm[s].input = argv[i];
+	  } else if (strcasecmp(argv[i], "--scale") == 0) {
+	i++;
+	int scale_code = get_scale_code(argv[i]);
+	args.scale = scale_code;
+	init_color_arg(args.colors, scale_code);
       } else if (strcasecmp(argv[i], "--format") == 0) {
 	i++;
 	args.storm[s].format = argv[i];

--- a/tracks/track.c
+++ b/tracks/track.c
@@ -37,6 +37,9 @@
     }						\
   }						\
 
+#  define COLOR(r, g, b) {((double)(r) / (double)0xFF),	\
+			  ((double)(g) / (double)0xFF),	\
+			  ((double)(b) / (double)0xFF)}
 struct args {
   struct storm_arg *storm;
   int nstorms;
@@ -120,6 +123,7 @@ static struct args read_args(int argc, char **argv)
     .template = true,
     .bg = "../data/bg8192.png",
     .output = "../png/output.png",
+	//.tscolor = 
   };
 
   args.storm = malloc(sizeof(*args.storm));
@@ -473,12 +477,9 @@ static void get_color(double *r, double *g, double *b, struct pos *pos)
     {1, 0.3, 1}, /* 4 */
     {1, 1, 1} /* 5 */
   };
-#else
-#  define COLOR(r, g, b) {((double)(r) / (double)0xFF),	\
-			  ((double)(g) / (double)0xFF),	\
-			  ((double)(b) / (double)0xFF)}
+#elif 0
+
     /* Wikipedia colors */
-#if 0
   /* Old colors. */
   double colors[7][3] = {
     COLOR(0x00, 0xFF, 0xFF), /* DEP */
@@ -500,7 +501,6 @@ static void get_color(double *r, double *g, double *b, struct pos *pos)
     COLOR(0xff, 0x8f, 0x20), /* cat4 */
     COLOR(0xff, 0x60, 0x60) /* cat5 */
   };
-#endif
 #endif
   int i;
   double unknown[3] = COLOR(0xc0, 0xc0,0xc0);

--- a/tracks/track.c
+++ b/tracks/track.c
@@ -84,8 +84,8 @@ static void help(void)
   printf("  --extra  			Do not cut off the extratropical portion of the tracks when extra≠0\n");
   printf("  --dots   			Set size of dots, in degrees\n");
   printf("  --lines  			Set size of lines, in degrees\n");
-  printf("  --scale             Set the TC classification scale to use for this map (default: SSHWS). Valid values are SSHWS, AUS, IMD, JMA, or MFR. The input file's winds are assumed to be over the correct averaging interval (e.g. 3-minute sustained winds for the IMD scale. If specified, this argument MUST be given before any color arguments.");
-  printf("  --<category>color   Set the color of this category (default: classic SSHWS color), for example --c5color 000000. Must be a hexadecimal color code with or without the 0x prefix. Multiple arguments of this type may be specified. As valid category names depend on the scale used, these arguments MUST be specified after --scale if that is specified.\n");
+  printf("  --scale  			Set the TC classification scale to use for this map (default: SSHWS). Valid values are SSHWS, AUS, IMD, JMA, or MFR. The input file's winds are assumed to be over the correct averaging interval (e.g. 3-minute sustained winds for the IMD scale. If specified, this argument MUST be given before any color arguments.\n");
+  printf("  --<category>color		Set the color of this category (default: classic SSHWS color), for example --c5color 000000. Must be a hexadecimal color code with or without the 0x prefix. Multiple arguments of this type may be specified. As valid category names depend on the scale used, these arguments MUST be specified after --scale if that is specified.\n");
   printf("More than one storm can be included on the map with the \n"
 	 "use of the --next field.  The year, name, input, id, and\n"
 	 "format fields apply to a storm.  Each time --next is given\n"

--- a/tracks/track.c
+++ b/tracks/track.c
@@ -3,7 +3,7 @@
  * Distributed under the GPL.  See http://gnu.org/.
  *
  * Compile as
- *   gcc -g -Wall -Werror template.c tab.c track.c tcr.c atcf.c hurdat2.c hurdat.c md.c `pkg-config --cflags --libs cairo` -o track
+ *   gcc -g -Wall -Werror scales.c template.c tab.c track.c tcr.c atcf.c hurdat2.c hurdat.c md.c `pkg-config --cflags --libs cairo` -o track
  */
 
 #include <assert.h>

--- a/tracks/track.c
+++ b/tracks/track.c
@@ -55,6 +55,7 @@ struct args {
   double alpha;
   const char *bg;
   const char *output;
+  int scale;
   struct colormap *colors;
 };
 
@@ -83,7 +84,8 @@ static void help(void)
   printf("  --extra  			Do not cut off the extratropical portion of the tracks when extra≠0\n");
   printf("  --dots   			Set size of dots, in degrees\n");
   printf("  --lines  			Set size of lines, in degrees\n");
-  printf("  --<category>color   Set the color of this category (default: classic SSHWS color), for example --c5color 000000. Must be a hexadecimal color code with or without the 0x prefix.\n");
+  printf("  --scale             Set the TC classification scale to use for this map (default: SSHWS). Valid values are SSHWS, AUS, IMD, JMA, or MFR. The input file's winds are assumed to be over the correct averaging interval (e.g. 3-minute sustained winds for the IMD scale. If specified, this argument MUST be given before any color arguments.");
+  printf("  --<category>color   Set the color of this category (default: classic SSHWS color), for example --c5color 000000. Must be a hexadecimal color code with or without the 0x prefix. Multiple arguments of this type may be specified. As valid category names depend on the scale used, these arguments MUST be specified after --scale if that is specified.\n");
   printf("More than one storm can be included on the map with the \n"
 	 "use of the --next field.  The year, name, input, id, and\n"
 	 "format fields apply to a storm.  Each time --next is given\n"
@@ -113,7 +115,19 @@ static void init_storm_arg(struct storm_arg *stormp)
 static void init_color_arg(struct colormap *colorp, int scale) {
 	struct colormap colors;
    switch (scale) {
-	   default:
+		case AUS_CODE:
+			colors = AUS_COLORMAP;
+		break;
+		case IMD_CODE:
+			colors = IMD_COLORMAP;
+		break;
+		case JMA_CODE:
+			colors = JMA_COLORMAP;
+		break;
+		case MFR_CODE:
+			colors = MFR_COLORMAP;
+		break;
+		default:
 			colors = SSHWS_COLORMAP;
    }
    *colorp = colors;
@@ -173,6 +187,7 @@ static struct args read_args(int argc, char **argv)
     .template = true,
     .bg = "../data/bg8192.png",
     .output = "../png/output.png",
+	.scale = SSHWS_CODE
   };
 
   args.storm = malloc(sizeof(*args.storm));

--- a/tracks/track.c
+++ b/tracks/track.c
@@ -52,6 +52,7 @@ struct args {
   double alpha;
   const char *bg;
   const char *output;
+  double tdcolor, tscolor, c1color, c2color, c3color, c4color, c5color;
 };
 
 #define NO_ARG -200
@@ -123,7 +124,13 @@ static struct args read_args(int argc, char **argv)
     .template = true,
     .bg = "../data/bg8192.png",
     .output = "../png/output.png",
-	//.tscolor = 
+    .tdcolor = COLOR(0x5e, 0xba, 0xff), /* DEP */
+    .tscolor = COLOR(0x00, 0xfa, 0xf4), /* TS */
+    .c1color = COLOR(0xff, 0xff, 0xcc), /* cat1 */
+    .c2color = COLOR(0xff, 0xe7, 0x75), /* cat2 */
+    .c3color = COLOR(0xff, 0xc1, 0x40), /* cat3 */
+    .c4color = COLOR(0xff, 0x8f, 0x20), /* cat4 */
+    .c5color = COLOR(0xff, 0x60, 0x60) /* cat5 */
   };
 
   args.storm = malloc(sizeof(*args.storm));

--- a/tracks/track.c
+++ b/tracks/track.c
@@ -84,7 +84,7 @@ static void help(void)
   printf("  --extra  			Do not cut off the extratropical portion of the tracks when extra≠0\n");
   printf("  --dots   			Set size of dots, in degrees\n");
   printf("  --lines  			Set size of lines, in degrees\n");
-  printf("  --scale  			Set the TC classification scale to use for this map (default: SSHWS). Valid values are SSHWS, AUS, IMD, JMA, or MFR. The input file's winds are assumed to be over the correct averaging interval (e.g. 3-minute sustained winds for the IMD scale. If specified, this argument MUST be given before any color arguments.\n");
+  printf("  --scale  			Set the TC classification scale to use for this map (default: SSHWS). Valid values are SSHWS, AUS, IMD, JMA, or MFR. The input file's winds are assumed to be over the correct averaging interval (e.g. 3-minute sustained winds for the IMD scale). If specified, this argument MUST be given before any color arguments.\n");
   printf("  --<category>color		Set the color of this category (default: classic SSHWS color), for example --c5color 000000. Must be a hexadecimal color code with or without the 0x prefix. Multiple arguments of this type may be specified. As valid category names depend on the scale used, these arguments MUST be specified after --scale if that is specified.\n");
   printf("More than one storm can be included on the map with the \n"
 	 "use of the --next field.  The year, name, input, id, and\n"


### PR DESCRIPTION
This is a significant change to the implementation of the code. The motivation is to ease the testing of new colors for https://en.wikipedia.org/wiki/Wikipedia_talk:WikiProject_Tropical_cyclones#Track_map_overhauls since we need a new color scheme. This entailed the introduction of a new _colormap_ data structure. For now, it is statically allocated, but it allows for much easier support of multiple scales by removing the "hard-coded" nature of the previous implementation; allocating this data structure's arrays dynamically would allow support for other scales (which all have different numbers of categories). The new command-line arguments are also automatically generated from the colormap data structure and therefore the implementation would not have to be changed for new scales.