### PR TITLE
Force LF for Cygwin users

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Force lf for Cygwin users with a local .gitconfig
+*.sh eol=lf


### PR DESCRIPTION
Cygwin users with a local `.gitconfig` file on their home (`~`) directory (equivalent to `C:\Users\<user>\`)  will clone the repository with CRLF line endings if `core.autocrlf` was set to `true`. This can make `autogen.sh` fail to run when running through cygwin with the following error:
```
./autogen.sh: line 5: $'\r': command not found
./autogen.sh: line 7: $'\r': command not found
./autogen.sh: line 22: syntax error near unexpected token `$'\r''
'/autogen.sh: line 22: `version_check()
```
This pull request fixes the issue by introducing a `.gitattributes` file that forces LF line endings for `.sh` files. This can be later modified to include more files, but so far only has `.sh` files since gcc and perl should both automatically handle CRLF file endings.