### PR TITLE
Add extern keyword to scales header

### DIFF
--- a/tracks/scales.h
+++ b/tracks/scales.h
@@ -19,15 +19,15 @@ struct colormap {
 	double disturbancecolor[3]; // For PTC/DI/TDI. Can be overridden using the distcolor argument.
 	// The disturbance color is considered separately from the other entries since unlike the others, it is not uniquely determined by storm intensity, overlapping with depressions.
 };
-struct colormapentry SSHWS_ENTRIES[8];
-struct colormap SSHWS_COLORMAP;
-struct colormapentry AUS_ENTRIES[7];
-struct colormap AUS_COLORMAP;
-struct colormapentry IMD_ENTRIES[8];
-struct colormap IMD_COLORMAP;
-struct colormapentry JMA_ENTRIES[5];
-struct colormap JMA_COLORMAP;
-struct colormapentry MFR_ENTRIES[8];
-struct colormap MFR_COLORMAP;
-struct colormapentry JMADOM_ENTRIES[7];
-struct colormap JMADOM_COLORMAP;
+extern struct colormapentry SSHWS_ENTRIES[8];
+extern struct colormap SSHWS_COLORMAP;
+extern struct colormapentry AUS_ENTRIES[7];
+extern struct colormap AUS_COLORMAP;
+extern struct colormapentry IMD_ENTRIES[8];
+extern struct colormap IMD_COLORMAP;
+extern struct colormapentry JMA_ENTRIES[5];
+extern struct colormap JMA_COLORMAP;
+extern struct colormapentry MFR_ENTRIES[8];
+extern struct colormap MFR_COLORMAP;
+extern struct colormapentry JMADOM_ENTRIES[7];
+extern struct colormap JMADOM_COLORMAP;


### PR DESCRIPTION
Initial declaration of headers are performed in `scales.h`, of which `scales.c` includes. On gcc (GCC) 10.2.0 (provided by Cygwin), this leads to a "first defined here" error.
```
# (paths simplified for brevity)
gcc -I/usr/include/cairo -I/usr/include/glib-2.0 -I/usr/lib/glib-2.0/include -I/usr/include/pixman-1 -I/usr/include/freetype2 -I/usr/include/libpng16 -I/usr/include/uuid  -g -O2   -o track.exe scales.o template.o tab.o tcr.o atcf.o hurdat2.o hurdat.o md.o track.o -lcairo
/bin/ld: track.o:~/wptc-track/tracks/scales.h:23: multiple definition of `SSHWS_COLORMAP'; scales.o:~/wptc-track/tracks/scales.h:23: first defined here
/bin/ld: track.o:~/wptc-track/tracks/scales.h:25: multiple definition of `AUS_COLORMAP'; scales.o:~/wptc-track/tracks/scales.h:25: first defined here
/bin/ld: track.o:~/wptc-track/tracks/scales.h:27: multiple definition of `IMD_COLORMAP'; scales.o:~/wptc-track/tracks/scales.h:27: first defined here
/bin/ld: track.o:~/wptc-track/tracks/scales.h:33: multiple definition of `JMADOM_COLORMAP'; scales.o:~/wptc-track/tracks/scales.h:33: first defined here
/bin/ld: track.o:~/wptc-track/tracks/scales.h:31: multiple definition of `MFR_COLORMAP'; scales.o:~/wptc-track/tracks/scales.h:31: first defined here
/bin/ld: track.o:~/wptc-track/tracks/scales.h:29: multiple definition of `JMA_COLORMAP'; scales.o:~/wptc-track/tracks/scales.h:29: first defined here
/bin/ld: track.o:~/wptc-track/tracks/scales.h:32: multiple definition of `JMADOM_ENTRIES'; scales.o:~/wptc-track/tracks/scales.h:32: first defined here
/bin/ld: track.o:~/wptc-track/tracks/scales.h:30: multiple definition of `MFR_ENTRIES'; scales.o:~/wptc-track/tracks/scales.h:30: first defined here
/bin/ld: track.o:~/wptc-track/tracks/scales.h:28: multiple definition of `JMA_ENTRIES'; scales.o:~/wptc-track/tracks/scales.h:28: first defined here
/bin/ld: track.o:~/wptc-track/tracks/scales.h:26: multiple definition of `IMD_ENTRIES'; scales.o:~/wptc-track/tracks/scales.h:26: first defined here
/bin/ld: track.o:~/wptc-track/tracks/scales.h:24: multiple definition of `AUS_ENTRIES'; scales.o:~/wptc-track/tracks/scales.h:24: first defined here
/bin/ld: track.o:~/wptc-track/tracks/scales.h:22: multiple definition of `SSHWS_ENTRIES'; scales.o:~/wptc-track/tracks/scales.h:22: first defined here
```
Adding the `extern` keyword to the initial declarations in the header file should prevent the linker from assuming that the scales are defined in the header file. Compilation proceeds properly with this change on the aforementioned gcc version, and also works when tested with gcc (Debian 8.3.0-6) 8.3.0.