### PR TITLE
Minor: Fix unused variable and OBO mistake

### DIFF
--- a/tracks/jma.c
+++ b/tracks/jma.c
@@ -50,7 +50,6 @@ struct stormdata *read_stormdata_jma(struct stormdata *storms, struct storm_arg*
 	char *token[9]; // JMA BT files have only nine tokens max per line.
 	int dateset = 0;
 	int points = 0;
-	int lasttype;
 	struct pos pos;
 	int count = 0;
 	file = fopen(args->input, "r");
@@ -94,7 +93,6 @@ struct stormdata *read_stormdata_jma(struct stormdata *storms, struct storm_arg*
 			points = 0;
 			dateset = 0;
 		} else if (strcmp(token[1], "002") == 0) { // Data lines always have 002 as second token
-			struct pos pos;
 			int date = atoi(token[0]);
 			pos.year = get_full_year(date/1000000);
 			pos.month = (date % 1000000)/10000;
@@ -112,7 +110,6 @@ struct stormdata *read_stormdata_jma(struct stormdata *storms, struct storm_arg*
 			} else {
 				pos.type = TROPICAL;  // JMA doesn't do ST
 			}
-			lasttype = pos.type;
 			pos.lat = atoi(token[3])/10.0;
 			pos.lon = -atoi(token[4])/10.0;
 			pos.wind = atoi(token[6]);

--- a/tracks/scales.c
+++ b/tracks/scales.c
@@ -60,8 +60,8 @@ struct colormapentry JMA_ENTRIES[7] = {
 	{.name = "TS", .value = COLOR(0x4d, 0xff, 0xff), .wind = 34},
 	{.name = "STS", .value = COLOR(0xc0, 0xff, 0xc0), .wind = 48},
 	{.name = "TY", .value = COLOR(0xff, 0xd9, 0x8c), .wind = 64},
-	{.name = "VSTY", .value = COLOR(0xff, 0x73, 0x8a), .wind = 85},
-        {.name = "VITY", .value = COLOR(0xa1, 0x88, 0xfc), .wind = 105},
+	{.name = "VSTY", .value = COLOR(0xff, 0x73, 0x8a), .wind = 84},
+        {.name = "VITY", .value = COLOR(0xa1, 0x88, 0xfc), .wind = 104},
 	{.name = "SENTINEL", .value = COLOR(0xff, 0xff, 0xff), .wind = 0x7fffffff}
 };
 struct colormap JMA_COLORMAP = {
@@ -93,8 +93,8 @@ struct colormapentry JMADOM_ENTRIES[7] = {
         {.name = "TS", .value = COLOR(0x4d, 0xff, 0xff), .wind = 34},
         {.name = "STS", .value = COLOR(0xc0, 0xff, 0xc0), .wind = 48},
         {.name = "TY", .value = COLOR(0xff, 0xd9, 0x8c), .wind = 64},
-        {.name = "VSTY", .value = COLOR(0xff, 0x73, 0x8a), .wind = 85},
-        {.name = "VITY", .value = COLOR(0xa1, 0x88, 0xfc), .wind = 105},
+        {.name = "VSTY", .value = COLOR(0xff, 0x73, 0x8a), .wind = 84},
+        {.name = "VITY", .value = COLOR(0xa1, 0x88, 0xfc), .wind = 104},
         {.name = "SENTINEL", .value = COLOR(0xff, 0xff, 0xff), .wind = 0x7fffffff}
 };
 struct colormap JMADOM_COLORMAP = {


### PR DESCRIPTION
Apparently the gcc command at https://en.wikipedia.org/wiki/Wikipedia:WikiProject_Tropical_cyclones/Tracks is stricter with linting than with make and I only tested with make.